### PR TITLE
feat: Rails Detection Module (#1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: test test-file lint
+
+PLENARY ?= $(shell nvim --headless -c "lua print(vim.fn.stdpath('data') .. '/lazy/plenary.nvim')" -c "qa" 2>/dev/null)
+
+test:
+	nvim --headless -u NONE \
+		-c "set rtp+=." \
+		-c "set rtp+=$(PLENARY)" \
+		-c "lua require('plenary.test_harness').test_directory('tests/', { minimal_init = 'tests/minimal_init.lua' })" \
+		-c "qa"
+
+test-file:
+	nvim --headless -u NONE \
+		-c "set rtp+=." \
+		-c "set rtp+=$(PLENARY)" \
+		-c "lua require('plenary.busted').run('$(FILE)')" \
+		-c "qa"
+
+lint:
+	luacheck lua/ --globals vim --no-unused-args

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,20 @@
 .PHONY: test test-file lint
 
-PLENARY ?= $(shell nvim --headless -c "lua print(vim.fn.stdpath('data') .. '/lazy/plenary.nvim')" -c "qa" 2>/dev/null)
+PLENARY ?= $(shell nvim --headless -c "lua io.write(vim.fn.stdpath('data') .. '/lazy/plenary.nvim')" -c "qa" 2>/dev/null)
 
 test:
 	nvim --headless -u NONE \
 		-c "set rtp+=." \
 		-c "set rtp+=$(PLENARY)" \
-		-c "lua require('plenary.test_harness').test_directory('tests/', { minimal_init = 'tests/minimal_init.lua' })" \
+		-c "runtime plugin/plenary.vim" \
+		-c "lua require('plenary.test_harness').test_directory('tests/', {minimal_init='tests/minimal_init.lua'})" \
 		-c "qa"
 
 test-file:
 	nvim --headless -u NONE \
 		-c "set rtp+=." \
 		-c "set rtp+=$(PLENARY)" \
+		-c "runtime plugin/plenary.vim" \
 		-c "lua require('plenary.busted').run('$(FILE)')" \
 		-c "qa"
 

--- a/lua/rails-tools/detectors/init.lua
+++ b/lua/rails-tools/detectors/init.lua
@@ -1,0 +1,22 @@
+local rails = require("rails-tools.detectors.rails")
+
+-- Phase 2+: register rspec and grape detectors here alongside rails.
+---@class Detectors
+local M = {}
+
+---@return {is_rails: boolean, root: string}|nil
+function M.detect()
+  return rails.detect()
+end
+
+---@return string|nil
+function M.root()
+  return rails.root()
+end
+
+---@return boolean
+function M.is_rails()
+  return rails.is_rails()
+end
+
+return M

--- a/lua/rails-tools/detectors/rails.lua
+++ b/lua/rails-tools/detectors/rails.lua
@@ -1,0 +1,64 @@
+local M = {}
+
+---@type table<string, {is_rails: boolean, root: string}|false>
+local cache = {}
+
+---@param dir string
+---@param name string
+---@return boolean
+local function file_exists(dir, name)
+  local path = dir .. "/" .. name
+  return vim.fn.filereadable(path) == 1 or vim.fn.isdirectory(path) == 1
+end
+
+---@param start_dir string
+---@return string|nil
+local function find_root(start_dir)
+  local dir = start_dir
+  while true do
+    local has_gemfile = vim.fn.filereadable(dir .. "/Gemfile") == 1
+    local has_rails = file_exists(dir, "bin/rails") or file_exists(dir, "script/rails")
+    if has_gemfile and has_rails then
+      return dir
+    end
+    local parent = vim.fn.fnamemodify(dir, ":h")
+    if parent == dir then
+      return nil
+    end
+    dir = parent
+  end
+end
+
+---@param cwd? string
+---@return {is_rails: boolean, root: string}|nil
+function M.detect(cwd)
+  local start_dir = cwd or vim.fn.getcwd()
+  if cache[start_dir] ~= nil then
+    return cache[start_dir] or nil
+  end
+  local root = find_root(start_dir)
+  if root then
+    if cache[root] == nil then
+      cache[root] = { is_rails = true, root = root }
+    end
+    local result = cache[root]
+    cache[start_dir] = result
+    ---@cast result {is_rails: boolean, root: string}
+    return result
+  end
+  cache[start_dir] = false
+  return nil
+end
+
+---@return string|nil
+function M.root()
+  local result = M.detect()
+  return result and result.root or nil
+end
+
+---@return boolean
+function M.is_rails()
+  return M.detect() ~= nil
+end
+
+return M

--- a/specs/issues/001-rails-detection.md
+++ b/specs/issues/001-rails-detection.md
@@ -1,6 +1,6 @@
 ## **Status:**
 - Review: Approved
-- PR: Todo
+- PR: Draft
 
 ## Metadata
 - **Title:** Rails Detection

--- a/tests/detectors/rails_spec.lua
+++ b/tests/detectors/rails_spec.lua
@@ -1,0 +1,131 @@
+local rails
+
+describe("rails detector", function()
+  local tmp_dir
+  local orig_cwd
+
+  before_each(function()
+    orig_cwd = vim.fn.getcwd()
+    tmp_dir = vim.fn.tempname()
+    vim.fn.mkdir(tmp_dir, "p")
+    package.loaded["rails-tools.detectors.rails"] = nil
+    rails = require("rails-tools.detectors.rails")
+  end)
+
+  after_each(function()
+    vim.fn.delete(tmp_dir, "rf")
+    vim.cmd("cd " .. orig_cwd)
+  end)
+
+  local function create_file(path)
+    local full = tmp_dir .. "/" .. path
+    local dir = vim.fn.fnamemodify(full, ":h")
+    vim.fn.mkdir(dir, "p")
+    vim.fn.writefile({}, full)
+  end
+
+  describe("detect()", function()
+    it("returns result with is_rails=true for valid Rails project (bin/rails)", function()
+      create_file("Gemfile")
+      create_file("bin/rails")
+      local result = rails.detect(tmp_dir)
+      assert.is_not_nil(result)
+      assert.is_true(result.is_rails)
+      assert.equals(tmp_dir, result.root)
+    end)
+
+    it("returns result with is_rails=true for valid Rails project (script/rails)", function()
+      create_file("Gemfile")
+      create_file("script/rails")
+      local result = rails.detect(tmp_dir)
+      assert.is_not_nil(result)
+      assert.is_true(result.is_rails)
+    end)
+
+    it("returns nil for project with Gemfile but no bin/rails", function()
+      create_file("Gemfile")
+      local result = rails.detect(tmp_dir)
+      assert.is_nil(result)
+    end)
+
+    it("returns nil for project with bin/rails but no Gemfile", function()
+      create_file("bin/rails")
+      local result = rails.detect(tmp_dir)
+      assert.is_nil(result)
+    end)
+
+    it("returns nil for non-Rails project", function()
+      local result = rails.detect(tmp_dir)
+      assert.is_nil(result)
+    end)
+
+    it("caches and reuses detection result (same table reference)", function()
+      create_file("Gemfile")
+      create_file("bin/rails")
+      local first = rails.detect(tmp_dir)
+      vim.fn.delete(tmp_dir .. "/Gemfile")
+      -- cache hit returns same object, not a re-traversal
+      local second = rails.detect(tmp_dir)
+      assert.are.equal(first, second)
+    end)
+
+    it("negative result is cached (no re-traversal on second call)", function()
+      local first = rails.detect(tmp_dir)
+      assert.is_nil(first)
+      -- second call should also return nil without traversal
+      local second = rails.detect(tmp_dir)
+      assert.is_nil(second)
+    end)
+
+    it("detects Rails root by traversing up from subdirectory", function()
+      create_file("Gemfile")
+      create_file("bin/rails")
+      local subdir = tmp_dir .. "/app/models"
+      vim.fn.mkdir(subdir, "p")
+      local result = rails.detect(subdir)
+      assert.is_not_nil(result)
+      assert.equals(tmp_dir, result.root)
+    end)
+
+    it("two subdirs of same project share cached result", function()
+      create_file("Gemfile")
+      create_file("bin/rails")
+      local sub1 = tmp_dir .. "/app"
+      local sub2 = tmp_dir .. "/lib"
+      vim.fn.mkdir(sub1, "p")
+      vim.fn.mkdir(sub2, "p")
+      local r1 = rails.detect(sub1)
+      local r2 = rails.detect(sub2)
+      -- both point to the same root-keyed cache entry
+      assert.are.equal(r1, r2)
+    end)
+  end)
+
+  describe("root()", function()
+    it("returns root path for Rails project", function()
+      create_file("Gemfile")
+      create_file("bin/rails")
+      vim.cmd("cd " .. tmp_dir)
+      assert.equals(tmp_dir, rails.root())
+    end)
+
+    it("returns nil for non-Rails project", function()
+      vim.cmd("cd " .. tmp_dir)
+      assert.is_nil(rails.root())
+    end)
+  end)
+
+  describe("is_rails()", function()
+    it("returns true for Rails project", function()
+      create_file("Gemfile")
+      create_file("bin/rails")
+      vim.cmd("cd " .. tmp_dir)
+      assert.is_true(rails.is_rails())
+    end)
+
+    it("returns false for non-Rails project", function()
+      vim.cmd("cd " .. tmp_dir)
+      assert.is_false(rails.is_rails())
+    end)
+  end)
+end)

--- a/tests/detectors/rails_spec.lua
+++ b/tests/detectors/rails_spec.lua
@@ -106,7 +106,8 @@ describe("rails detector", function()
       create_file("Gemfile")
       create_file("bin/rails")
       vim.cmd("cd " .. tmp_dir)
-      assert.equals(tmp_dir, rails.root())
+      -- resolve() handles macOS /var -> /private/var symlink
+      assert.equals(vim.fn.resolve(tmp_dir), vim.fn.resolve(rails.root()))
     end)
 
     it("returns nil for non-Rails project", function()


### PR DESCRIPTION
Implements the Rails project detection module that identifies whether the current directory is inside a Rails project by traversing up the directory tree.

## What was implemented

- `lua/rails-tools/detectors/rails.lua` — core detection logic with detect(), root(), is_rails() functions and a root-keyed cache so all subdirectories of the same project share one cache entry
- `lua/rails-tools/detectors/init.lua` — orchestrator entry point (Phase 2 will register rspec/grape detectors here)
- `tests/detectors/rails_spec.lua` — 11 tests covering valid Rails projects (bin/rails and script/rails), non-Rails projects, negative caching, subdirectory traversal, and shared cache across siblings
- `Makefile` — make test, make test-file, make lint targets per CLAUDE.md spec

## Issue
closes #1